### PR TITLE
feat: standardized archetypes and article-creator skill

### DIFF
--- a/.gemini/skills/article-creator.skill
+++ b/.gemini/skills/article-creator.skill
@@ -1,0 +1,6 @@
+{
+  "name": "article-creator",
+  "description": "Automates the creation of new article bundles, including GitHub issue tracking, feature branch isolation, and front matter standardization.",
+  "location": ".gemini/skills/article-creator/SKILL.md",
+  "status": "active"
+}

--- a/.gemini/skills/article-creator/SKILL.md
+++ b/.gemini/skills/article-creator/SKILL.md
@@ -27,6 +27,11 @@ Automates the creation of new article bundles, including GitHub issue tracking, 
 
 Provide the article slug (e.g., `my-new-post`) and any initial Markdown content. The skill will handle the infrastructure setup.
 
+## Implementation
+
+To execute this workflow, use the supporting Python script:
+`python3 .gemini/skills/article-creator/create_article.py <slug> [optional_content_file]`
+
 ## Standards
 
 -   **Slug Formatting:** Slugs should be lowercase and hyphen-separated.

--- a/.gemini/skills/article-creator/SKILL.md
+++ b/.gemini/skills/article-creator/SKILL.md
@@ -1,0 +1,34 @@
+# Article Creator
+
+Automates the creation of new article bundles, including GitHub issue tracking, feature branch isolation, and front matter standardization.
+
+## Core Workflow
+
+1.  **Issue Creation:**
+    -   Given an article slug, create a GitHub issue tagged as an `enhancement`.
+    -   This ensures the new article is tracked in the project backlog.
+
+2.  **Branch Isolation:**
+    -   Create a new feature branch specifically for the new article (e.g., `feature/article-<slug>`).
+    -   This keeps the `main` branch clean during the draft and review phase.
+
+3.  **Bundle Generation:**
+    -   Use the `hugo new --kind article-bundle articles/<slug>` command to generate a new leaf bundle.
+    -   This ensures all required front matter (title, date, categories, tags, etc.) is included.
+
+4.  **Front Matter Initialization:**
+    -   Automatically set the `status` property in the front matter to `"user-review"`.
+    -   Optionally append provided Markdown content to the `index.md` file.
+
+5.  **User Notification:**
+    -   Provide the user with the path to the newly created `index.md` and the name of the feature branch.
+
+## Usage
+
+Provide the article slug (e.g., `my-new-post`) and any initial Markdown content. The skill will handle the infrastructure setup.
+
+## Standards
+
+-   **Slug Formatting:** Slugs should be lowercase and hyphen-separated.
+-   **Front Matter:** Always include the governance-checked categories and tags placeholders.
+-   **Status:** The initial status for automated creation is always `"user-review"`.

--- a/.gemini/skills/article-creator/create_article.py
+++ b/.gemini/skills/article-creator/create_article.py
@@ -1,0 +1,93 @@
+import os
+import sys
+import subprocess
+import re
+
+def clean_slug(slug):
+    # Remove any non-alphanumeric characters (except hyphens) and convert to lowercase
+    slug = slug.lower()
+    slug = re.sub(r'[^a-z0-9-]', '-', slug)
+    slug = re.sub(r'-+', '-', slug)
+    return slug.strip('-')
+
+def run_command(command):
+    try:
+        result = subprocess.run(command, shell=True, check=True, capture_output=True, text=True)
+        return result.stdout.strip()
+    except subprocess.CalledProcessError as e:
+        print(f"Error executing command: {command}")
+        print(f"Error output: {e.stderr}")
+        sys.exit(1)
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python create_article.py <slug> [content_file]")
+        sys.exit(1)
+
+    raw_slug = sys.argv[1]
+    slug = clean_slug(raw_slug)
+    content = ""
+    
+    if len(sys.argv) > 2:
+        content_file = sys.argv[2]
+        if os.path.exists(content_file):
+            with open(content_file, 'r') as f:
+                content = f.read()
+
+    # 1. Create GitHub Issue
+    # Note: This assumes 'gh' CLI is installed and authenticated
+    title = f"Enhancement: New Article - {slug.replace('-', ' ').title()}"
+    body = f"Proposed new article: {slug}\n\nAutomated issue created by article-creator skill."
+    print(f"Creating GitHub issue: {title}")
+    issue_output = run_command(f'gh issue create --title "{title}" --body "{body}" --label "enhancement"')
+    print(f"Issue created: {issue_output}")
+
+    # 2. Create Feature Branch
+    branch_name = f"feature/article-{slug}"
+    print(f"Creating feature branch: {branch_name}")
+    run_command(f"git checkout -b {branch_name}")
+
+    # 3. Use Hugo new to create the article
+    article_path = f"articles/{slug}"
+    print(f"Running hugo new for {article_path}")
+    run_command(f"hugo new --kind article-bundle {article_path}")
+
+    # 4. Update front matter status to "user-review" and add optional content
+    index_path = os.path.join("content", "articles", slug, "index.md")
+    if os.path.exists(index_path):
+        with open(index_path, 'r') as f:
+            lines = f.readlines()
+
+        new_lines = []
+        in_frontmatter = False
+        frontmatter_count = 0
+        
+        for line in lines:
+            if line.strip() == "---":
+                frontmatter_count += 1
+                new_lines.append(line)
+                continue
+            
+            if frontmatter_count == 1:
+                if line.startswith("status:"):
+                    new_lines.append('status: "user-review"\n')
+                else:
+                    new_lines.append(line)
+            else:
+                new_lines.append(line)
+
+        # If content is provided, append it after the front matter
+        if content:
+            # The archetype index.md ends with a newline and some boilerplate text. 
+            # We will append our content at the very end.
+            new_lines.append("\n")
+            new_lines.append(content)
+
+        with open(index_path, 'w') as f:
+            f.writelines(new_lines)
+
+    print(f"\nArticle '{slug}' is available for review at: {index_path}")
+    print(f"Branch: {branch_name}")
+
+if __name__ == "__main__":
+    main()

--- a/archetypes/article-bundle/index.md
+++ b/archetypes/article-bundle/index.md
@@ -12,4 +12,5 @@ tags:
 showReadingTime: true
 showTableOfContents: true
 draft: true
+status: agent-pending
 ---

--- a/archetypes/article-bundle/index.md
+++ b/archetypes/article-bundle/index.md
@@ -1,0 +1,15 @@
+---
+title: "{{ replace .Name "-" " " | title }}"
+date: {{ .Date }}
+# externalUrl: ""
+summary: ""
+description: ""
+# Assign exactly one category: Strategy, Leadership, Fintech, Energy Transition, Technology, Venture Building, Essays
+categories:
+  - ""
+tags:
+  - ""
+showReadingTime: true
+showTableOfContents: true
+draft: true
+---

--- a/archetypes/lab-bundle/index.md
+++ b/archetypes/lab-bundle/index.md
@@ -5,12 +5,13 @@ summary: ""
 description: ""
 # Assign exactly one category: Strategy, Leadership, Fintech, Energy Transition, Technology, Venture Building, Essays
 categories:
-  - "Technology"
+  - ""
 tags:
   - ""
 showReadingTime: true
 showTableOfContents: true
 draft: true
+status: agent-pending
 ---
 
 This is a lab leaf bundle. Use this for technical deep dives, experiments, and architectural breakdowns.

--- a/archetypes/lab-bundle/index.md
+++ b/archetypes/lab-bundle/index.md
@@ -1,0 +1,16 @@
+---
+title: "{{ replace .Name "-" " " | title }}"
+date: {{ .Date }}
+summary: ""
+description: ""
+# Assign exactly one category: Strategy, Leadership, Fintech, Energy Transition, Technology, Venture Building, Essays
+categories:
+  - "Technology"
+tags:
+  - ""
+showReadingTime: true
+showTableOfContents: true
+draft: true
+---
+
+This is a lab leaf bundle. Use this for technical deep dives, experiments, and architectural breakdowns.


### PR DESCRIPTION
This PR introduces standardized Hugo archetypes for article and lab bundles, and a new Gemini CLI skill to automate article creation.

### Changes:
- **Archetypes:** Added `article-bundle` and `lab-bundle` with common front matter (summary, description, categories, tags, TOC/Reading time settings).
- **Front Matter:** Added a `status` field (default: `agent-pending`) to track article lifecycle.
- **Skill:** Created `article-creator` skill that automates:
    1. GitHub issue creation (tagged enhancement).
    2. Feature branch creation.
    3. 'Hugo new' bundle generation.
    4. Front matter update to `user-review`.

Fixes #16