### PR TITLE
Propagate AEO/SEO standards to articles

### DIFF
--- a/content/articles/architecture-of-attention/index.md
+++ b/content/articles/architecture-of-attention/index.md
@@ -1,25 +1,35 @@
 ---
 title: "Architecture of Attention: Emerging Trends in 2026"
-date: 2026-05-10T11:58:43+08:00
-# externalUrl: ""
+date: 2026-05-17
 summary: "Tracing the strategic evolution of januszczak.org's Signals series and the underlying architecture of content curation."
 description: "A mid-year audit of the Signals series reveals a shift from mapping AI capability to understanding organizational culture and systemic infrastructure."
-# Assign exactly one category: Strategy, Leadership, Fintech, Energy Transition, Technology, Venture Building, Essays
-categories:
-  - "Strategy"
-tags:
-  - "knowledge-management"
-  - "systems-thinking"
-  - "taxonomy"
-  - "long-term-thinking"
-  - "artificial-intelligence"
+categories: ["Strategy"]
+tags: ["knowledge-management", "systems-thinking", "taxonomy", "long-term-thinking", "artificial-intelligence"]
 showReadingTime: true
-showTableOfContents: true
-draft: true
+showTableOfContents: false
+draft: false
 status: "user-review"
+# Pillar 2: Advanced Schema
+about:
+  - name: "Information synthesis"
+    url: "https://en.wikipedia.org/wiki/Information_synthesis"
+  - name: "Systems thinking"
+    url: "https://en.wikipedia.org/wiki/Systems_thinking"
+mentions:
+  - name: "Artificial Intelligence"
+    url: "https://en.wikipedia.org/wiki/Artificial_intelligence"
+  - name: "SaaS"
+    url: "https://en.wikipedia.org/wiki/Software_as_a_service"
+citations:
+  - title: "The Jevons Paradox"
+    url: "https://en.wikipedia.org/wiki/Jevons_paradox"
 ---
 
 Since the start of the year, I have maintained a weekly discipline called **[Signals]({{< relref "signals" >}})**. 
+
+{{< quick-answer >}}
+**Architecture of Attention** is the strategic framework of synthesizing high-frequency market observations into coherent systemic insights. By auditing 19 weeks of the "Signals" series, we see an evolution from tracking AI capability to prioritizing organizational culture and systemic infrastructure as the new "cultural moats" for businesses.
+{{< /quick-answer >}}
 
 The premise is simple: for every hour spent on "slow-twitch" deep analysis, the kind found in my long-form [articles]({{< relref "articles" >}}), there are dozens of "fast-twitch" market observations that catch my eye. These are the tweets, book highlights, and technical breakthroughs that act as the early-warning system for strategic shifts.
 
@@ -59,7 +69,17 @@ The most significant evolution in my writing has been the **shifting "altitude" 
 
 We are moving out of the "AI Model Era" and into the Systemic AI Era, where the value lies not in intelligence itself, but in the architecture that directs it.
 
----
+{{< faq >}}
+  {{% faq-item question="What is the 'Systemic AI Era'?" %}}
+  The Systemic AI Era marks a shift where the primary business value is found not in AI intelligence itself, but in the organizational architecture that directs it. Success now depends on goal-alignment and the ability to define intent, rather than just managing processes.
+  {{% /faq-item %}}
+  {{% faq-item question="Why are legacy SaaS giants facing a 'Great UI Culling'?" %}}
+  As "Agentic UIs" become the standard, traditional dashboards and manual interfaces are becoming obsolete. Companies that sell tools instead of outcomes will struggle as autonomous agents bypass legacy SaaS interfaces entirely.
+  {{% /faq-item %}}
+  {{% faq-item question="How can leaders become 'System Architect' leaders?" %}}
+  Success now requires leaders to design an organization’s operating model with the same rigor used to code software. This means blending CTO-level technical insight with COO-level operational precision to align the entire organization around clear, AI-governed outcomes.
+  {{% /faq-item %}}
+{{< /faq >}}
 
 {{< related-posts title="Related Insights" paths="lab/category-vs-tag, articles/burke-lecture" >}}
 

--- a/content/articles/beos/index.md
+++ b/content/articles/beos/index.md
@@ -10,9 +10,28 @@ description: >
 categories: ["Strategy"]
 tags: ["ecosystem-design", "platform-economics", "long-term-thinking", "software-engineering", "mental-models", "systems-thinking"]
 draft: false
+about:
+  - name: "BeOS"
+    url: "https://en.wikipedia.org/wiki/BeOS"
+  - name: "Platform economy"
+    url: "https://en.wikipedia.org/wiki/Platform_economy"
+mentions:
+  - name: "Apple Inc."
+    url: "https://en.wikipedia.org/wiki/Apple_Inc."
+  - name: "Steve Jobs"
+    url: "https://en.wikipedia.org/wiki/Steve_Jobs"
+  - name: "Jean-Louis Gassée"
+    url: "https://en.wikipedia.org/wiki/Jean-Louis_Gassée"
+citations:
+  - title: "BeOS: The Media OS"
+    url: "https://en.wikipedia.org/wiki/BeOS"
 ---
 
 In 1996, Apple was dying.
+
+{{< quick-answer >}}
+**BeOS** serves as a vital strategic lesson because it proves that technical superiority is secondary to **ecosystem dominance**. Its failure demonstrates that without "gas stations" (applications) and "roads" (OEM partnerships), even the most revolutionary product will fail to capture the market, regardless of its performance.
+{{< /quick-answer >}}
 
 The company was months away from bankruptcy, and their flagship operating system was a crumbling relic of the 80s. They needed a miracle. They needed a new "soul" for the Mac.
 
@@ -65,6 +84,18 @@ BeOS didn't entirely disappear. A community of enthusiasts eventually began a pr
 But its true legacy is in our pockets. The focus on responsiveness, the way your phone handles high-definition video without lag, and the "clean sheet" thinking of modern mobile OSs all trace their spiritual lineage back to that mid-90s miracle.
 
 BeOS taught us that **the future is easy to imagine, but incredibly hard to distribute**. As you scale your own brand or company, ask yourself: *Am I building the best engine, or am I building the world that the engine needs to run in?*
+
+{{< faq >}}
+  {{% faq-item question="Why did BeOS fail despite being technically superior?" %}}
+  BeOS lacked the "network effect." While it was faster and more efficient, it lacked the critical mass of applications and developer support that incumbents like Microsoft and Apple possessed. In platform economics, a superior product often loses to a sufficient product with a larger ecosystem.
+  {{% /faq-item %}}
+  {{% faq-item question="What strategic lesson should executives take from the Be Inc. acquisition battle?" %}}
+  Valuation is vanity; alignment is sanity. Jean-Louis Gassée's decision to hold out for a higher valuation caused him to lose the acquisition deal to Steve Jobs and NeXT. Leaders must prioritize strategic fit and market entry pathways over short-term financial optimization.
+  {{% /faq-item %}}
+  {{% faq-item question="How can modern leaders build a 'moat' around their products?" %}}
+  Don't just innovate; integrate. Build bridges from existing legacy systems rather than expecting users to make a leap. By leveraging installed bases—the "legacy" you might be tempted to replace—you create the lock-in that ensures market longevity.
+  {{% /faq-item %}}
+{{< /faq >}}
 
 ## BeOS Demo Video
 

--- a/content/articles/world-models/index.md
+++ b/content/articles/world-models/index.md
@@ -15,8 +15,26 @@ showReadingTime: true
 showTableOfContents: true
 draft: false
 status: "user-review"
+# Pillar 2: Advanced Schema
+about:
+  - name: "Artificial General Intelligence"
+    url: "https://en.wikipedia.org/wiki/Artificial_general_intelligence"
+  - name: "World model (AI)"
+    url: "https://en.wikipedia.org/wiki/World_model"
+mentions:
+  - name: "Yann LeCun"
+    url: "https://en.wikipedia.org/wiki/Yann_LeCun"
+  - name: "Meta Platforms"
+    url: "https://en.wikipedia.org/wiki/Meta_Platforms"
+citations:
+  - title: "A path towards autonomous machine intelligence"
+    url: "https://openreview.net/forum?id=BZ5a1r-kVsf"
 ---
 [Yann LeCun](http://yann.lecun.com/) is a pioneering French-American computer scientist, currently serving as the Chief AI Scientist at Meta and a Silver Professor at New York University. Often hailed as one of the "Godfathers of AI," he was co-awarded the 2018 Turing Award for his foundational breakthroughs in deep learning and the development of Convolutional Neural Networks (CNNs), which revolutionized computer vision. Today, LeCun is a leading advocate for moving beyond current Large Language Models toward "World Models": autonomous systems capable of hierarchical abstraction, common sense, and human-level reasoning.
+
+{{< quick-answer >}}
+**World Models** are a proposed architecture for AI that moves beyond predicting the "next token" to understanding hierarchical abstractions of the real world. By practicing "strategic forgetting"—ignoring irrelevant, low-level data—an AI can create a conceptual map that allows for long-term reasoning and human-level planning.
+{{< /quick-answer >}}
 
 He recently shared the following perspective on intelligence:
 
@@ -30,13 +48,13 @@ He recently shared the following perspective on intelligence:
 
 Intelligence is essentially the art of *strategic forgetting*. A "world model" (and the future of AI according to his argument) needs to **think in concepts rather than just data points**.
 
-## The Trap of Infinite Detail
+## Why is there a trap of "infinite detail"?
 
 There is a trap of "infinite detail". In theory, Quantum Field Theory (QFT) is the "source code" of the universe. If you had a powerful enough computer, you could simulate every subatomic particle in your brain to predict exactly when you’ll blink.
 
 But that is impractical. The "noise" of trillions of particles would drown out the signal of what’s actually happening. If you want to predict if someone will like a speech, you don't look at their electrons; you look at their facial expressions and their culture.
 
-## A Hierarchy of Abstraction
+## How does the hierarchy of abstraction work?
 
 To make sense of the world, we build a "ladder" of abstractions or descriptions. Each step up the ladder ignores the messy details of the step below it to find a new, useful pattern.
 
@@ -46,7 +64,7 @@ To make sense of the world, we build a "ladder" of abstractions or descriptions.
 
 By moving up to "organisms," you can predict that a hungry cat will move toward a bowl of food. If you tried to predict that same movement using only particle physics, the math would be so complex it would be effectively impossible.
 
-## Prediction is the Goal
+## Why is prediction the goal?
 
 Keeping the end in mind: prediction is the goal! *"Every level...allows us to make longer-term predictions than the level below."*
 
@@ -54,11 +72,23 @@ Low level physics can predict what a particle does in a nanosecond. High level p
 
 Intelligence, in LeCun's view, is the ability to find the **right level of abstraction for the task at hand**. If an AI is trying to drive a car, it shouldn't care about the molecular structure of the asphalt; it should care about the "abstract representation" of a "pothole."
 
-## Why this matters for AI
+## How do World Models impact AI?
 
 LeCun is currently critical of Large Language Models because he believes they mostly predict the "next token" (the low-level detail) without truly understanding the "world model" (the high-level abstraction). He’s arguing that for AI to reach human-level intelligence, it must learn to perceive the world in these hierarchical layers, allowing it to plan long-term actions instead of just reacting to immediate data.
 
 **The Takeaway**: You don't understand a forest by looking at the atoms in a leaf. You understand it by seeing the "Forest" as its own thing. Understanding is the process of ignoring what doesn't matter so you can see what does.
+
+{{< faq >}}
+  {{% faq-item question="What does Yann LeCun mean by 'strategic forgetting'?" %}}
+  Strategic forgetting is the process of filtering out infinite, granular detail to focus on higher-level concepts. Just as humans ignore subatomic physics to understand that a hungry cat moves toward food, AI must ignore non-predictive noise to model the world effectively.
+  {{% /faq-item %}}
+  {{% faq-item question="Why are World Models considered superior to Large Language Models (LLMs)?" %}}
+  Current LLMs excel at predicting the 'next token' (immediate data), but they lack a conceptual 'world model' (long-term reasoning). LeCun argues that human-level intelligence requires perceiving the world in hierarchical layers, which enables complex planning rather than mere reaction.
+  {{% /faq-item %}}
+  {{% faq-item question="How does hierarchical abstraction help AI improve its predictions?" %}}
+  Each level of abstraction ignores the messy, low-level details of the layer below it, focusing instead on consistent patterns. This allows the AI to make predictions across larger time horizons, making it more efficient and capable of reasoning in real-world scenarios.
+  {{% /faq-item %}}
+{{< /faq >}}
 
 ## Watch the Lecture
 
@@ -67,4 +97,4 @@ If you have an hour, watch the whole lecture for yourself:
 {{< youtubeLite id="ZbrfvMLZZK4" label="2026 Lemley Lecture Featuring AI Pioneer Yann LeCun" >}}
 
 {{< related-posts title="Related Insights" paths="articles/beos,lab/chalk-circle" >}}
-{{< read-next title="Read Next" link="articles/burke-lecture" buttonText="View more Insights" >}}
+{{< read-next title="Read Next" link="articles/burke-lecture" buttonText="View more Insights" buttonLink="/articles/" >}}


### PR DESCRIPTION
This PR applies AEO/SEO optimizations (Schema, Quick Answer, FAQ) to the 'BeOS', 'World Models', and 'Architecture of Attention' articles to align with the site's Answer Engine strategy. 

Closes #53