### PR TITLE
feat: add editorial agent workflow

### DIFF
--- a/.agents/skills/content-creator/SKILL.md
+++ b/.agents/skills/content-creator/SKILL.md
@@ -7,8 +7,9 @@ Automates the technical provisioning of all site content types (Articles, Resear
 1.  **Identify Content Type:**
     -   Determine the type of content requested (Article, Research, Video, Lab, Portfolio, or Signals).
     -   If unclear, ask the user for clarification.
-2.  **Issue Creation:**
-    -   Create a GitHub issue tagged as an `enhancement` for the specific content type.
+2.  **Issue Creation or Reuse:**
+    -   Create a GitHub issue tagged as an `enhancement` when invoked directly without one.
+    -   Reuse the existing backlog issue when an outer editorial agent provides its issue identifier. Never create a duplicate issue.
 3.  **Branch Isolation:**
     -   Create a new feature branch in the format `feature/<type>-<slug>`.
 4.  **Bundle Provisioning:**
@@ -24,6 +25,9 @@ Automates the technical provisioning of all site content types (Articles, Resear
 
 To execute this workflow, use the supporting Python script:
 `uv run python .agents/skills/content-creator/scripts/create_content.py <content_type> <slug>`
+
+To reuse a backlog issue and create a branch linked to it:
+`uv run python .agents/skills/content-creator/scripts/create_content.py <content_type> <slug> --issue <number>`
 
 **Available Types:** `article`, `research`, `video`, `lab`, `portfolio`, `signals`.
 

--- a/.agents/skills/content-creator/scripts/create_content.py
+++ b/.agents/skills/content-creator/scripts/create_content.py
@@ -1,73 +1,90 @@
-import os
-import sys
-import subprocess
-import re
+#!/usr/bin/env python3
+"""Provision a Hugo content bundle, optionally against an existing GitHub issue."""
 
-# Mapping of user-friendly names to Hugo archetype kinds and content directories
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+
+
 CONTENT_TYPE_MAP = {
     "article": {"kind": "article-bundle", "dir": "articles"},
     "research": {"kind": "research-bundle", "dir": "research"},
     "video": {"kind": "video-bundle", "dir": "videos"},
     "lab": {"kind": "lab-bundle", "dir": "lab"},
     "portfolio": {"kind": "portfolio-bundle", "dir": "portfolio"},
-    "signals": {"kind": "signals-bundle", "dir": "signals"}
+    "signals": {"kind": "signals-bundle", "dir": "signals"},
 }
 
+
 def clean_slug(slug):
-    # Remove any non-alphanumeric characters (except hyphens) and convert to lowercase
-    slug = slug.lower()
-    slug = re.sub(r'[^a-z0-9-]', '-', slug)
-    slug = re.sub(r'-+', '-', slug)
-    return slug.strip('-')
+    slug = re.sub(r"[^a-z0-9-]", "-", slug.lower())
+    return re.sub(r"-+", "-", slug).strip("-")
 
-def run_command(command):
-    try:
-        result = subprocess.run(command, shell=True, check=True, capture_output=True, text=True)
-        return result.stdout.strip()
-    except subprocess.CalledProcessError as e:
-        print(f"Error executing command: {command}")
-        print(f"Error output: {e.stderr}")
-        sys.exit(1)
 
-def main():
-    if len(sys.argv) < 3:
-        print("Usage: python create_content.py <content_type> <slug>")
-        print(f"Available types: {', '.join(CONTENT_TYPE_MAP.keys())}")
-        sys.exit(1)
+def run(command):
+    result = subprocess.run(command, capture_output=True, text=True)
+    if result.returncode:
+        print(f"Error executing command: {' '.join(command)}", file=sys.stderr)
+        print(result.stderr.strip(), file=sys.stderr)
+        raise SystemExit(result.returncode)
+    return result.stdout.strip()
 
-    content_type = sys.argv[1].lower()
-    raw_slug = sys.argv[2]
-    
-    if content_type not in CONTENT_TYPE_MAP:
-        print(f"Error: Unknown content type '{content_type}'")
-        print(f"Available types: {', '.join(CONTENT_TYPE_MAP.keys())}")
-        sys.exit(1)
 
-    slug = clean_slug(raw_slug)
-    type_info = CONTENT_TYPE_MAP[content_type]
-
-    # 1. Create GitHub Issue
+def create_issue(content_type, slug):
     title = f"Enhancement: New {content_type.capitalize()} - {slug.replace('-', ' ').title()}"
     body = f"Proposed new {content_type}: {slug}\n\nInfrastructure provisioned by content-creator skill."
-    print(f"Creating GitHub issue: {title}")
-    issue_output = run_command(f'gh issue create --title "{title}" --body "{body}" --label "enhancement"')
-    print(f"Issue created: {issue_output}")
+    issue_url = run(["gh", "issue", "create", "--title", title, "--body", body, "--label", "enhancement"])
+    return int(issue_url.rstrip("/").split("/")[-1]), issue_url
 
-    # 2. Create Feature Branch
-    branch_name = f"feature/{content_type}-{slug}"
-    print(f"Creating feature branch: {branch_name}")
-    run_command(f"git checkout -b {branch_name}")
 
-    # 3. Use Hugo new to create the content bundle
+def main():
+    parser = argparse.ArgumentParser(description="Provision a Hugo content bundle")
+    parser.add_argument("content_type", choices=CONTENT_TYPE_MAP)
+    parser.add_argument("slug")
+    parser.add_argument("--issue", type=int, help="Reuse this existing GitHub backlog issue")
+    parser.add_argument("--branch", help="Branch name when reusing an existing issue")
+    args = parser.parse_args()
+
+    content_type = args.content_type
+    slug = clean_slug(args.slug)
+    if not slug:
+        parser.error("slug must contain letters or numbers")
+
+    type_info = CONTENT_TYPE_MAP[content_type]
     hugo_path = f"{type_info['dir']}/{slug}"
-    print(f"Running hugo new for {hugo_path} using kind {type_info['kind']}")
-    run_command(f"hugo new --kind {type_info['kind']} {hugo_path}")
+    index_path = os.path.join("content", type_info["dir"], slug, "index.md")
 
-    index_path = os.path.join("content", type_info['dir'], slug, "index.md")
-    print(f"\n[INFRASTRUCTURE READY]")
-    print(f"Content Type: {content_type}")
-    print(f"File Path: {index_path}")
-    print(f"Branch: {branch_name}")
+    if os.path.exists(index_path):
+        parser.error(f"content bundle already exists: {index_path}")
+
+    if args.issue:
+        issue_number = args.issue
+        issue_url = run(["gh", "issue", "view", str(issue_number), "--json", "url", "--jq", ".url"])
+        branch_name = args.branch or f"feature/{issue_number}-{content_type}-{slug}"
+        print(f"Reusing GitHub issue #{issue_number}: {issue_url}")
+        print(f"Creating linked branch: {branch_name}")
+        run(["gh", "issue", "develop", str(issue_number), "--name", branch_name, "--checkout"])
+    else:
+        issue_number, issue_url = create_issue(content_type, slug)
+        branch_name = f"feature/{content_type}-{slug}"
+        print(f"Created GitHub issue #{issue_number}: {issue_url}")
+        print(f"Creating feature branch: {branch_name}")
+        run(["git", "checkout", "-b", branch_name])
+
+    print(f"Running hugo new for {hugo_path} using kind {type_info['kind']}")
+    run(["hugo", "new", "--kind", type_info["kind"], hugo_path])
+    print(json.dumps({
+        "content_type": content_type,
+        "slug": slug,
+        "issue": issue_number,
+        "issue_url": issue_url,
+        "branch": branch_name,
+        "index_path": index_path,
+    }))
+
 
 if __name__ == "__main__":
     main()

--- a/.agents/skills/editorial-agent/SKILL.md
+++ b/.agents/skills/editorial-agent/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: editorial-agent
+description: Turn an approved CEO Playbook GitHub editorial-backlog issue into a review-ready draft package. Use when Codex must claim an `editorial:ready` issue, choose a content section, research or refine a draft, coordinate content skills, source a featured image, prepare social drafts, validate the bundle, and open a linked PR without publishing.
+---
+
+# Editorial Agent
+
+Own the editorial job from an eligible GitHub Issue through a review-ready PR. Stop before merging, publishing, or posting to social channels.
+
+Read [workflow.md](references/workflow.md) before starting a job. Read `assets/notes.md` before creating the bundle-local audit record.
+
+## Completion contract
+
+Complete a job only when its post has `draft: true`, the required bundle assets and `notes.md` exist, content checks pass, X and LinkedIn candidates have been saved under `docs/repurposed/`, and a PR linked to the original issue is open.
+
+Never change `draft` to `false`, merge a PR, publish, or post social content unless the user explicitly asks.
+
+## Workflow
+
+1. Claim one open issue labelled `editorial:ready`, confirm it is not `editorial:blocked`, and change its state to `editorial:in-progress`. Post the claim comment from the workflow reference.
+2. Read the brief, supplied material, and authority constraints. Stop and mark the issue blocked if the brief lacks usable material and does not authorize research.
+3. Propose the content type from the brief. Use Articles for strategic analysis, Labs for technical work, Videos for a primary video URL, and Research for evidence-led analysis. Record the choice in the issue.
+4. Invoke `content-research-writer` when the issue needs research or a full draft. Preserve a supplied draft unless substantial rewriting is authorized.
+5. Invoke `content-creator` with the existing issue identifier. Do not create a second issue. Create a new issue only when this skill is invoked directly without one.
+6. Invoke `managing-editor` to enforce taxonomy, metadata, AEO structure, internal links, and draft status. Force `draft: true` regardless of supplied frontmatter.
+7. Source three featured-image candidates. Prefer licensed real photography. When `PIXABAY_API_KEY` is available, use `scripts/find_pixabay_candidates.py` and read `references/pixabay.md`. Record candidate URLs, rights basis, and selection rationale. Commit only the selected 16:9 landscape asset. Use image generation only when real photography cannot express the argument and the brief does not prohibit it.
+8. Create `notes.md` from the bundled template. Include the concise decision record, not private reasoning.
+9. Invoke `repurpose-social` to save X and LinkedIn candidates under `docs/repurposed/`. Draft only. Do not post.
+10. Run Managing Editor checks and `uv run python .agents/skills/editorial-agent/evals/runner.py <bundle> --social-draft <path>`. Apply two targeted correction passes. On a third unresolved failure, mark the issue `editorial:blocked`, post the report, and stop.
+11. Commit the content package, social draft archive, and audit notes. Open a PR that closes the original issue, apply `editorial:review`, post the handoff comment, and stop.
+
+## Authority
+
+Act without approval only for the issue states, drafting, existing taxonomy, feature-image selection with clear rights, branch creation, validation, and PR creation defined above.
+
+Require human approval for a new category or tag, private or paid sources without explicit issue permission, changing unrelated published posts, publishing, merging, and social posting.
+
+## Resources
+
+- `scripts/claim_next_issue.py`: Find or claim one eligible issue. Use `--dry-run` before scheduling an automation.
+- `scripts/find_pixabay_candidates.py`: Return horizontal real-photo candidates when `PIXABAY_API_KEY` is available.
+- `scripts/validate_editorial_package.py`: Verify local review-ready artifacts.
+- `evals/runner.py`: Run local package validation and the Hugo build, then save a structured report.
+- `assets/notes.md`: Copy into the content leaf bundle as `notes.md`.
+- `references/workflow.md`: State labels, comment formats, image policy, and recovery rules.

--- a/.agents/skills/editorial-agent/agents/openai.yaml
+++ b/.agents/skills/editorial-agent/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Editorial Agent"
+  short_description: "Turn approved briefs into review-ready posts"
+  default_prompt: "Use $editorial-agent to process the next approved CEO Playbook editorial issue."

--- a/.agents/skills/editorial-agent/assets/notes.md
+++ b/.agents/skills/editorial-agent/assets/notes.md
@@ -1,0 +1,15 @@
+# Editorial Notes
+
+## Brief and intended reader
+
+## Content-type and taxonomy rationale
+
+## Research basis and citations
+
+## Featured image candidates and selected asset
+
+## Social draft archive
+
+## Validation record
+
+## Open questions and human decisions

--- a/.agents/skills/editorial-agent/evals/runner.py
+++ b/.agents/skills/editorial-agent/evals/runner.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Run Editorial Agent deterministic checks for one content package."""
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+
+
+def run(command, cwd=None):
+    result = subprocess.run(command, capture_output=True, text=True, cwd=cwd)
+    return {
+        "status": "PASS" if result.returncode == 0 else "FAIL",
+        "stdout": result.stdout.strip(),
+        "stderr": result.stderr.strip(),
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("bundle", type=Path)
+    parser.add_argument("--social-draft", type=Path, required=True)
+    args = parser.parse_args()
+
+    skill_project_root = Path(__file__).resolve().parents[4]
+    project_root = Path.cwd().resolve()
+    validator = skill_project_root / ".agents/skills/editorial-agent/scripts/validate_editorial_package.py"
+    bundle = args.bundle.resolve()
+    social_draft = args.social_draft.resolve()
+    package = run(
+        [sys.executable, str(validator), str(bundle), "--social-draft", str(social_draft)],
+        project_root,
+    )
+    hugo = run(["hugo", "--minify"], project_root)
+    report = {
+        "timestamp": datetime.now().isoformat(),
+        "bundle": str(bundle),
+        "social_draft": str(social_draft),
+        "overall_status": "PASS" if package["status"] == "PASS" and hugo["status"] == "PASS" else "FAIL",
+        "checks": [
+            {"id": "editorial_package", "name": "Editorial package validation", **package},
+            {"id": "hugo_build", "name": "Hugo build", **hugo},
+        ],
+    }
+    reports = Path(__file__).resolve().parent / "reports"
+    reports.mkdir(exist_ok=True)
+    (reports / "latest_results.json").write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps(report, indent=2))
+    raise SystemExit(0 if report["overall_status"] == "PASS" else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/editorial-agent/references/pixabay.md
+++ b/.agents/skills/editorial-agent/references/pixabay.md
@@ -1,0 +1,7 @@
+# Pixabay Image Search
+
+Use `scripts/find_pixabay_candidates.py` with `PIXABAY_API_KEY` to search for real-photo candidates. The tool reads the key from the process environment first, then from the project-root `.env` file. Do not commit `.env`.
+
+The adapter calls the official Pixabay image endpoint with `image_type=photo`, `orientation=horizontal`, and `safesearch=true`. It rejects results tagged `AI generated`. Pixabay requires the application to show the source when displaying API search results, rate limits API keys, and disallows permanent hotlinking. Download an approved image into the Hugo leaf bundle rather than retaining a remote image URL. See [Pixabay API documentation](https://pixabay.com/api/docs/).
+
+Do not treat a search result as an automatic license decision. Record the candidate page URL, creator, selected download URL, and current use-rights basis in `notes.md` and the GitHub issue.

--- a/.agents/skills/editorial-agent/references/workflow.md
+++ b/.agents/skills/editorial-agent/references/workflow.md
@@ -1,0 +1,64 @@
+# Editorial Agent Workflow Reference
+
+## Backlog states
+
+| State | Meaning |
+| --- | --- |
+| `editorial:queued` | Idea needs a usable brief or explicit research authority. |
+| `editorial:ready` | Eligible for one agent run. |
+| `editorial:in-progress` | Claimed by an active agent. |
+| `editorial:blocked` | Waiting for missing authority, material, or a human decision. |
+| `editorial:review` | Linked PR is open and ready for review. |
+| `editorial:merged` | The content PR merged with `draft: true`. |
+| `editorial:publish-approved` | A human has authorized the separate release change. |
+| `editorial:published` | The release change merged and deployment was verified. |
+
+## Required issue comments
+
+Use concise, decision-useful updates. Do not expose private reasoning.
+
+### Claim
+
+```markdown
+## Editorial Agent claim
+
+- Status: `editorial:in-progress`
+- Branch: `<branch>`
+- Brief assessment: `<ready, blocked, or clarification needed>`
+- Next action: `<research, draft refinement, or provisioning>`
+```
+
+### Decision record
+
+```markdown
+## Editorial decision record
+
+- Content type: `<type>`
+- Rationale: `<one concise paragraph>`
+- Research basis: `<primary sources and permitted secondary sources>`
+- Taxonomy: `<category and tags, or approval request>`
+- Featured image: `<three candidate URLs, rights basis, and selection>`
+- Social drafts: `<path>`
+```
+
+### Handoff
+
+```markdown
+## Review-ready handoff
+
+- Bundle: `<path>`
+- Draft status: `true`
+- Validation: `<pass or blocker>`
+- PR: `<url>`
+- Human decisions: `<none or list>`
+```
+
+## Featured-image policy
+
+Record three candidates in `notes.md` and the issue. Prefer real photography from an approved source such as Pixabay. Require a direct source URL and rights or attribution basis for every candidate.
+
+Select only an image that is relevant, 16:9 landscape or crop-compatible, and free of substantial text, logos, and watermarks. Store the selected image as `featured.<extension>` in the bundle. Do not use an image with unclear rights.
+
+## Recovery
+
+Correct a failed deterministic check twice. After the second failed correction, label the issue `editorial:blocked`, remove `editorial:in-progress`, post the concise failure report, and stop.

--- a/.agents/skills/editorial-agent/scripts/claim_next_issue.py
+++ b/.agents/skills/editorial-agent/scripts/claim_next_issue.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Claim one eligible Editorial Agent backlog issue."""
+
+import argparse
+import json
+import subprocess
+import sys
+
+
+def run(command):
+    result = subprocess.run(command, capture_output=True, text=True)
+    if result.returncode:
+        print(result.stderr.strip(), file=sys.stderr)
+        raise SystemExit(result.returncode)
+    return result.stdout.strip()
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dry-run", action="store_true", help="Report the next eligible issue without changing it")
+    args = parser.parse_args()
+
+    raw = run([
+        "gh", "issue", "list", "--state", "open", "--label", "editorial:ready",
+        "--limit", "20", "--json", "number,title,body,labels,url",
+    ])
+    issues = json.loads(raw)
+    eligible = [
+        issue for issue in issues
+        if "editorial:blocked" not in {label["name"] for label in issue["labels"]}
+    ]
+    if not eligible:
+        print(json.dumps({"status": "empty", "message": "No eligible editorial backlog issues"}))
+        return
+
+    issue = sorted(eligible, key=lambda item: item["number"])[0]
+    result = {"status": "ready", "issue": issue}
+    if args.dry_run:
+        print(json.dumps(result))
+        return
+
+    number = str(issue["number"])
+    run([
+        "gh", "issue", "edit", number,
+        "--remove-label", "editorial:ready",
+        "--add-label", "editorial:in-progress",
+    ])
+    comment = (
+        "## Editorial Agent claim\n\n"
+        "- Status: `editorial:in-progress`\n"
+        "- Brief assessment: pending intake\n"
+        "- Next action: assess source material and select content type\n"
+    )
+    run(["gh", "issue", "comment", number, "--body", comment])
+    result["status"] = "claimed"
+    print(json.dumps(result))
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/editorial-agent/scripts/find_pixabay_candidates.py
+++ b/.agents/skills/editorial-agent/scripts/find_pixabay_candidates.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Return horizontal Pixabay photo candidates as structured JSON.
+
+Requires PIXABAY_API_KEY. This script searches only. The Editorial Agent must
+record rights and attribution before committing a selected asset.
+"""
+
+import argparse
+import json
+import os
+import ssl
+import sys
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import urlopen
+
+
+def project_root() -> Path:
+    """Return the repository root without relying on the current directory."""
+    for directory in Path(__file__).resolve().parents:
+        if (directory / ".git").exists():
+            return directory
+    raise RuntimeError("Could not locate the repository root")
+
+
+def pixabay_api_key() -> str | None:
+    """Read the key from the process environment or the project .env file.
+
+    Environment variables take precedence. The narrow parser intentionally reads
+    only PIXABAY_API_KEY and never writes it to stdout or logs.
+    """
+    key = os.environ.get("PIXABAY_API_KEY")
+    if key:
+        return key
+
+    env_file = project_root() / ".env"
+    if not env_file.is_file():
+        return None
+    for line in env_file.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line[7:].lstrip()
+        name, separator, value = line.partition("=")
+        if name.strip() != "PIXABAY_API_KEY" or not separator:
+            continue
+        return value.strip().strip('"').strip("'") or None
+    return None
+
+
+def tls_context() -> ssl.SSLContext:
+    """Use the host CA bundle when Python's default store is unavailable."""
+    configured_bundle = os.environ.get("SSL_CERT_FILE")
+    for candidate in (configured_bundle, "/etc/ssl/cert.pem"):
+        if candidate and Path(candidate).is_file():
+            return ssl.create_default_context(cafile=candidate)
+    return ssl.create_default_context()
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("query", help="Image-search phrase, maximum 100 characters")
+    parser.add_argument("--limit", type=int, default=3)
+    args = parser.parse_args()
+
+    key = pixabay_api_key()
+    if not key:
+        print(json.dumps({"errors": ["PIXABAY_API_KEY is required"]}))
+        raise SystemExit(1)
+    if not args.query.strip() or len(args.query) > 100:
+        parser.error("query must contain 1-100 characters")
+    if not 3 <= args.limit <= 20:
+        parser.error("limit must be between 3 and 20")
+
+    params = urlencode({
+        "key": key,
+        "q": args.query,
+        "image_type": "photo",
+        "orientation": "horizontal",
+        "safesearch": "true",
+        # Fetch a wider set because Pixabay can tag photo results as AI generated.
+        "per_page": min(200, max(20, args.limit * 5)),
+    })
+    try:
+        with urlopen(
+            f"https://pixabay.com/api/?{params}", timeout=20, context=tls_context()
+        ) as response:
+            payload = json.load(response)
+    except HTTPError as exc:
+        print(json.dumps({"errors": [f"Pixabay API returned HTTP {exc.code}"]}))
+        raise SystemExit(1)
+    except URLError as exc:
+        print(json.dumps({"errors": [f"Pixabay API request failed: {exc.reason}"]}))
+        raise SystemExit(1)
+
+    candidates = []
+    for hit in payload.get("hits", []):
+        tags = hit.get("tags", "")
+        if "ai generated" in tags.lower():
+            continue
+        candidates.append({
+            "id": hit["id"],
+            "source_url": hit["pageURL"],
+            "download_url": hit.get("largeImageURL") or hit.get("webformatURL"),
+            "creator": hit.get("user"),
+            "creator_url": f"https://pixabay.com/users/{hit.get('user')}-{hit.get('user_id')}/",
+            "width": hit.get("imageWidth"),
+            "height": hit.get("imageHeight"),
+            "tags": tags,
+            "license_basis": "Pixabay Content License, verify current terms before selection",
+        })
+        if len(candidates) == args.limit:
+            break
+    print(json.dumps({"query": args.query, "candidates": candidates}, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/editorial-agent/scripts/validate_editorial_package.py
+++ b/.agents/skills/editorial-agent/scripts/validate_editorial_package.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Validate local review-ready artifacts for an Editorial Agent content job."""
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+import yaml
+
+
+REQUIRED_NOTE_HEADINGS = {
+    "Brief and intended reader",
+    "Content-type and taxonomy rationale",
+    "Research basis and citations",
+    "Featured image candidates and selected asset",
+    "Social draft archive",
+    "Validation record",
+    "Open questions and human decisions",
+}
+
+
+def frontmatter(path: Path):
+    content = path.read_text(encoding="utf-8")
+    match = re.match(r"^---\s*\n(.*?)\n---\s*\n", content, re.DOTALL)
+    if not match:
+        raise ValueError("No YAML frontmatter found")
+    return yaml.safe_load(match.group(1)) or {}
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("bundle", type=Path, help="Content leaf bundle directory")
+    parser.add_argument("--social-draft", type=Path, required=True)
+    args = parser.parse_args()
+
+    errors = []
+    bundle = args.bundle
+    index = bundle / "index.md"
+    notes = bundle / "notes.md"
+
+    if not index.is_file():
+        errors.append(f"Missing index.md: {index}")
+    else:
+        try:
+            metadata = frontmatter(index)
+            if metadata.get("draft") is not True:
+                errors.append("Frontmatter must set draft: true")
+        except (OSError, ValueError, yaml.YAMLError) as exc:
+            errors.append(f"Invalid frontmatter: {exc}")
+
+    if not notes.is_file():
+        errors.append(f"Missing notes.md: {notes}")
+    else:
+        headings = {
+            line[3:].strip()
+            for line in notes.read_text(encoding="utf-8").splitlines()
+            if line.startswith("## ")
+        }
+        missing = sorted(REQUIRED_NOTE_HEADINGS - headings)
+        if missing:
+            errors.append(f"notes.md missing headings: {', '.join(missing)}")
+
+    if not any(bundle.glob("featured.*")):
+        errors.append("Missing selected featured image named featured.<extension>")
+
+    if not args.social_draft.is_file():
+        errors.append(f"Missing social draft archive: {args.social_draft}")
+    else:
+        social = args.social_draft.read_text(encoding="utf-8")
+        if "## X" not in social or "## LinkedIn" not in social:
+            errors.append("Social draft archive must contain X and LinkedIn sections")
+
+    if errors:
+        print(json.dumps({"errors": errors}))
+        raise SystemExit(1)
+    print(json.dumps({"message": "Editorial package is locally review-ready"}))
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/managing-editor/SKILL.md
+++ b/.agents/skills/managing-editor/SKILL.md
@@ -17,6 +17,7 @@ Activate this skill when the user wants to:
 ### 0. Phase 0: Provisioning & Normalization
 1.  **Infrastructure Provisioning (New Posts):**
     - If the request is to create a *new* post, you MUST first leverage the `content-creator` skill to provision the GitHub issue, feature branch, and leaf bundle.
+    - When an outer Editorial Agent supplies a backlog issue, pass it to `content-creator` with `--issue <number>` and reuse that issue. Do not create a duplicate issue.
     - Provide the `content-creator` with the `slug`.
     - Once provisioned, continue work in the new feature branch at the returned `index.md` path.
 2.  **Input Normalization:**
@@ -73,9 +74,11 @@ showReadingTime: false
     *   **Related/Read-Next:** MUST conclude with `{{< related-posts ... >}}` and `{{< read-next ... >}}`. Use `related-posts-suggester` and `read-next-suggester`.
     *   **Internal Linking:** After the draft is complete, use `internal-linker` for Articles, Videos, and Labs to identify contextual outgoing links, incoming-link opportunities, and an optional Further Reading section. Apply target-page edits only when authorized. Present edits to other published pages separately for approval. Do not force a Further Reading section or duplicate destinations already covered by `related-posts` or `read-next`.
 *   **Images:** Use `{{< figure src="image.png" alt="SEO text" caption="Visible caption" >}}`.
+*   **Draft protection:** Set `draft: true` for every newly created or edited agent-managed post. Publishing is a separate, explicit workflow.
 
 ### 4. Phase 4: Execution & Verification
 1.  **Propose:** Show the planned file path and frontmatter for approval.
+    - When an outer Editorial Agent has claimed an `editorial:ready` issue, the issue is the approved brief. Record the plan in the issue decision log and continue without an additional pause.
 2.  **Write:** Use `write_file` or `replace` to populate the `index.md`.
 
 ### 5. Phase 5: Self-Evaluation & Correction

--- a/.github/ISSUE_TEMPLATE/editorial-backlog.md
+++ b/.github/ISSUE_TEMPLATE/editorial-backlog.md
@@ -1,0 +1,23 @@
+---
+name: Editorial backlog item
+about: Queue an idea, brief, supplied draft, or video for the Editorial Agent
+title: "Editorial: "
+labels: ["editorial:queued"]
+assignees: []
+---
+
+## Editorial brief
+
+- Objective and reader:
+- Core claim or question:
+- Source material or full draft:
+- Required facts, links, or citations:
+- Optional content-type preference:
+- Video URL, if applicable:
+- Image direction or exclusions:
+- Private or paid-source permission, if applicable:
+- Approval constraints:
+
+## Editorial Agent instructions
+
+Apply `editorial:ready` only when this item has usable source material, a supplied full draft, or explicit permission for the agent to research and draft. The agent will create a review-ready PR with `draft: true`; it will not publish or post social content.

--- a/docs/editorial-agent-prd.md
+++ b/docs/editorial-agent-prd.md
@@ -1,0 +1,325 @@
+# Editorial Agent PRD and Implementation Plan
+
+**Status:** Draft for review  
+**Owner:** CEO Playbook  
+**Initial runtime:** Codex  
+**Design requirement:** The agent must remain portable to any capable outer agent or harness.
+
+## 1. Product Decision
+
+Build an Editorial Agent that turns an approved editorial backlog item into a governance-compliant, factually supported, on-brand, review-ready content package in the CEO Playbook repository.
+
+The agent owns the work across the editorial process. It does not own publication, final editorial judgment, or merger authority.
+
+The Managing Editor remains a reusable specialist skill. The Editorial Agent decides when to invoke it, research and drafting capabilities, image sourcing, validation, and GitHub operations.
+
+## 2. Goal and Completion Contract
+
+### Goal
+
+> For each approved editorial brief, produce a governance-compliant, factually supported, on-brand, review-ready content package in the CEO Playbook repository, and stop at the defined human approval boundary.
+
+### Completion
+
+A content job is complete when all of the following are true:
+
+1. A leaf bundle exists in the correct section and approved path.
+2. The content type, frontmatter, taxonomy, citations, internal links, and AEO elements meet the published rules.
+3. The selected featured image is relevant, licensed for use, 16:9 landscape, substantially free of text, and stored in the bundle with required attribution recorded.
+4. `notes.md` records the editorial brief, source basis, taxonomy rationale, image candidates and selection, validation outcomes, and unresolved questions.
+5. Required deterministic checks, including the Hugo build, pass.
+6. The post frontmatter explicitly sets `draft: true`.
+7. The work is committed and a GitHub PR linked to the original backlog issue is open.
+8. The GitHub issue contains a concise decision log and links to the branch, bundle, validations, and PR.
+9. The social-repurposing skill has produced review-ready candidate posts for X and LinkedIn, saved in the repository's `docs/repurposed/` archive and linked from the issue and `notes.md`.
+10. Any decision outside agent authority is marked for human review.
+
+The terminal state is **review-ready**. The agent does not publish, merge, distribute social posts, or change `draft` to `false` without a separate, explicit instruction.
+
+### Release policy
+
+Editorial completion and publication are separate events.
+
+1. The Editorial Agent always creates or updates a post with `draft: true`, including when the source material already contains `draft: false`.
+2. A reviewed PR can merge to `main` while the post remains a draft and therefore does not appear in the production Hugo build.
+3. A human explicitly approves publication after editorial review, using `editorial:publish-approved` or an equivalent explicit instruction.
+4. Publication is a small, separately auditable release change that sets only `draft: false` and confirms the production deployment.
+
+## 3. Scope
+
+### In scope
+
+- GitHub Issue backlog intake and state management.
+- Ideas, briefs, user-supplied drafts, links, and video URLs as source material.
+- Content-type selection across Articles, Labs, Videos, Research, and other supported CEO Playbook sections.
+- Research, drafting, editing, frontmatter generation, content provisioning, internal linking, image sourcing, validation, commit, and PR creation.
+- Draft social repurposing for X and LinkedIn using the existing `repurpose-social` skill.
+- A concise public decision log in GitHub and a local `notes.md` file.
+- Deterministic evaluation and limited self-correction.
+
+### Out of scope for the first release
+
+- Automatic merging or publishing.
+- Automatic posting to social channels.
+- Creation of new categories or tags without human approval.
+- Use of private or paid sources unless the issue explicitly grants access and permission.
+- Rewriting unrelated published content to create incoming links.
+
+## 4. Operating Model
+
+```text
+GitHub issue marked editorial:ready
+  → claim job and record start
+  → assess source material and content type
+  → research and draft, or edit a supplied draft
+  → provision branch and leaf bundle against the same issue
+  → invoke Managing Editor and supporting skills
+  → source and select featured image
+  → validate, correct, and revalidate
+  → create X and LinkedIn candidate posts
+  → commit and open PR
+  → record handoff and stop at review-ready
+```
+
+The agent is the outer orchestrator. It retains job state and chooses the next action. Its constituent skills own bounded procedures.
+
+## 5. GitHub Editorial Backlog
+
+### One issue per post
+
+One GitHub issue follows each post from idea to merge. It is the durable record for the brief, decisions, branch, PR, and human review.
+
+The existing `content-creator` and `managing-editor` flows must support two modes:
+
+1. **Agent mode:** Receive an existing eligible issue and create the branch, bundle, commit, and PR against that same issue. Do not create another issue.
+2. **Direct-use mode:** When invoked without an issue, create a new issue before provisioning the branch and leaf bundle, preserving the current standalone workflow.
+
+### Labels and states
+
+| Label | Meaning | Set by |
+| --- | --- | --- |
+| `editorial:queued` | Idea exists but lacks enough direction to start. | Human |
+| `editorial:ready` | Eligible for autonomous intake. | Human |
+| `editorial:in-progress` | Claimed by the agent. | Agent |
+| `editorial:blocked` | Missing authority, sources, or a human decision. | Agent or human |
+| `editorial:review` | PR is open and review-ready. | Agent |
+| `editorial:merged` | PR merged and repository state is complete. | Automation or human |
+| `editorial:publish-approved` | A human authorizes the separate release change from `draft: true` to `draft: false`. | Human |
+| `editorial:published` | The explicit release change is merged and deployment is confirmed. | Human or approved release automation |
+
+An automation selects only open issues labelled `editorial:ready`, excludes `editorial:blocked`, and processes one item per run unless explicitly configured otherwise. It posts a claim comment before branch creation to avoid duplicate work.
+
+### Issue template
+
+The backlog template should accept incomplete ideas, but define these fields when known:
+
+```markdown
+## Editorial brief
+- Objective and reader:
+- Core claim or question:
+- Source material or full draft:
+- Required facts, links, or citations:
+- Optional content-type preference:
+- Video URL, if applicable:
+- Image direction or exclusions:
+- Private or paid-source permission, if applicable:
+- Approval constraints:
+```
+
+`editorial:ready` requires an objective plus usable source material, a full draft, or explicit permission for the agent to research and draft from the idea.
+
+## 6. Content Classification and Drafting
+
+The agent proposes the section based on the brief, available evidence, and intended reader:
+
+| Signal | Likely section |
+| --- | --- |
+| Strategic thesis or operating lesson | Article |
+| Technical experiment, workflow, architecture, or tool learning | Lab |
+| A video URL or primary media asset | Video |
+| Evidence-led, reference-heavy deep analysis | Research |
+
+The content type is a proposal, not a hidden decision. The issue decision log records the rationale. A human can override it by editing the issue or applying a designated override label before the PR is created.
+
+### Research and drafting
+
+The agent uses a research-and-drafting capability before Managing Editor when the issue does not include a full draft. It must:
+
+1. Prefer primary sources.
+2. Use reputable reporting only when primary evidence is unavailable or insufficient.
+3. Separate evidence, inference, and opinion.
+4. Cite material factual and time-sensitive claims.
+5. Preserve supplied drafts unless the brief authorizes substantive rewriting.
+6. Draft in the established CEO Playbook voice: direct, first-person where appropriate, specific, operator-led, and free of generic AI language.
+
+Private or paid material is available only when the issue expressly states the permitted source or access route.
+
+## 7. Featured Image Policy
+
+### Objective
+
+Every eligible post receives one featured image suitable for Hugo.
+
+### Selection policy
+
+The agent sources three candidate images and scores them on:
+
+1. Relevance to the post's actual argument.
+2. Real-photo preference and editorial quality.
+3. License and attribution requirements.
+4. 16:9 landscape compatibility.
+5. Minimal or no embedded text, logo, watermark, or misleading visual claim.
+6. Fit with the CEO Playbook visual character.
+
+The agent records all three candidates, their source URLs, license or attribution basis, and its selection rationale in `notes.md` and the GitHub issue. It commits only the selected image to the content bundle.
+
+### Source order
+
+1. Licensed or freely usable real photography, beginning with Pixabay through an approved API or compliant retrieval path.
+2. Another approved stock or first-party source with clear use rights.
+3. AI-generated imagery only when suitable real photography cannot communicate the post well and the backlog does not prohibit it.
+
+The implementation must store the original source URL, creator attribution when required, license basis, selected filename, and image dimensions. It must not silently reuse images with unclear rights.
+
+## 8. Audit Record
+
+### GitHub issue comment
+
+The agent posts concise, decision-useful updates. It does not post hidden reasoning or chain-of-thought.
+
+Required entries:
+
+- Job claimed and branch created.
+- Content-type decision and rationale.
+- Research basis and source list.
+- Featured-image candidates and selection rationale.
+- Evaluation results and corrections made.
+- PR URL, artifact paths, and outstanding human decisions.
+
+### `notes.md` in the leaf bundle
+
+`notes.md` is a review aid, not published content. It should include:
+
+```markdown
+# Editorial Notes
+
+## Brief and intended reader
+## Content-type and taxonomy rationale
+## Research basis and citations
+## Featured image candidates and selected asset
+## Social draft archive
+## Validation record
+## Open questions and human decisions
+```
+
+The Hugo configuration must exclude `notes.md` from rendered site content, or the agent must use the repository's existing mechanism for non-rendered bundle notes.
+
+## 9. Authority and Human Gates
+
+| Action | Authority |
+| --- | --- |
+| Claim an eligible issue | Autonomous |
+| Choose a section from approved types | Autonomous, with logged rationale |
+| Create a branch, leaf bundle, commits, and PR | Autonomous |
+| Research public sources and draft | Autonomous |
+| Select an approved-license featured image | Autonomous |
+| Generate X and LinkedIn candidate posts | Autonomous |
+| Create a new tag or category | Human approval required |
+| Use private or paid material | Only with explicit issue permission |
+| Change `draft` to `false`, publish, merge, alter unrelated published content, or post social content | Explicit human instruction required |
+| Continue after repeated unresolved evaluation failures | Human review required |
+
+## 10. Evaluation and Recovery
+
+The Editorial Agent inherits the Managing Editor evaluation suite and adds agent-level checks.
+
+### Existing checks
+
+- Leaf bundle structure.
+- Governance-compliant frontmatter.
+- Required AEO elements.
+- Related and next-reading navigation.
+- Style restrictions.
+- Hugo build.
+
+### New checks
+
+- Backlog issue exists and is the issue linked by the resulting PR.
+- Correct editorial state transitions and decision-log comments.
+- `notes.md` exists and contains all required review fields.
+- Every cited external source has a title and URL.
+- Image is present when required, is landscape 16:9 or compatible with approved crop policy, and has no substantial embedded text.
+- Image source, attribution, and license basis are recorded.
+- Every agent-created post has `draft: true`, regardless of supplied frontmatter.
+- The agent cannot mark a job review-ready or create its PR if `draft: false`.
+- A social-draft archive exists for the post and contains X and LinkedIn candidates created by the existing `repurpose-social` skill.
+- No duplicate issue is created when the agent begins from an existing backlog issue.
+- PR remains in review-ready status and does not merge or publish.
+
+The agent gets two targeted correction passes after a failed evaluation. It reruns only the affected checks when practical. A third unresolved failure changes the issue to `editorial:blocked`, posts the failure report, and stops.
+
+## 11. Harness-Neutral Architecture
+
+The agent specification must describe capabilities, state, inputs, outputs, authority, and terminal conditions without relying on a specific vendor or framework.
+
+| Portable capability | Codex implementation |
+| --- | --- |
+| Read and update backlog | GitHub CLI or GitHub connector |
+| Repository worktree | Codex workspace and shell tools |
+| Specialist procedures | Skills such as Managing Editor, Content Creator, research/drafting, linking, and image curation |
+| External research and images | Approved web, API, or MCP tools |
+| Durable state | GitHub issue, branch, PR, `notes.md`, and the repository |
+| Scheduling | Codex automation that prompts the outer agent to claim the next eligible issue |
+| Human approval | Issue labels/comments, PR review, and explicit task instructions |
+
+In Codex, a top-level Codex task is the outer agent. The Editorial Agent will be a dedicated orchestration skill or equivalent durable instruction set that the task invokes. `AGENTS.md` retains non-negotiable repository policy. `config.toml` controls runtime configuration, not the agent's editorial logic.
+
+## 12. Implementation Plan
+
+### Phase 1: Specify the contract
+
+1. Approve this PRD and the exact issue-label convention.
+2. Add a GitHub Issue template for editorial backlog items.
+3. Add a harness-neutral Editorial Agent specification, including input schema, authority rules, state transitions, completion contract, and decision-log format.
+4. Define an automation prompt that selects one eligible issue and exits cleanly when the queue is empty.
+
+### Phase 2: Make existing skills issue-aware
+
+1. Update `content-creator` to accept an existing issue identifier and provision without creating a duplicate issue.
+2. Update `managing-editor` to receive and preserve the issue context through branch, draft, validation, and PR.
+3. Add or adapt a research-and-drafting skill that can draft from a brief or improve a supplied full draft.
+4. Add a `notes.md` template and confirm it will not render as public Hugo content.
+
+### Phase 3: Add image curation
+
+1. Create a featured-image curator capability with a source adapter for Pixabay and later approved providers.
+2. Add image-candidate scoring, license recording, 16:9 validation, text detection, and attribution output.
+3. Add the selected asset to the leaf bundle and link the attribution record to the issue and `notes.md`.
+4. Add explicit AI-image fallback rules.
+
+### Phase 4: Agent orchestration and evals
+
+1. Create the Editorial Agent orchestration skill for Codex.
+2. Connect the specialist skills in the required sequence with clear handoff inputs and outputs.
+3. Invoke `repurpose-social` after the content draft and canonical URL are established, then save its X and LinkedIn candidates in `docs/repurposed/`.
+4. Add agent-level validation checks and two-pass recovery logic.
+5. Add a dry-run mode that writes a plan and decision log without creating a branch or PR.
+6. Test against representative jobs: an idea-only issue, a supplied full draft, a video-based post, and a blocked private-source case.
+
+### Phase 5: Controlled automation
+
+1. Run the automation against one explicitly marked pilot issue at a time.
+2. Review the issue log, `notes.md`, PR quality, image selection, and correction behavior.
+3. Tighten authority and eval rules before increasing the schedule or concurrency.
+
+## 13. Acceptance Criteria
+
+The first production-ready version succeeds when it can take one `editorial:ready` issue, create no duplicate issue, select or honor the content section, produce a cited draft with `draft: true`, a selected featured image, and X and LinkedIn candidate posts, pass all checks, create one linked PR, write the required audit trail, and stop for human review without publishing, merging, or posting social content.
+
+## 14. Decisions Still Required Before Implementation
+
+1. Confirm the exact GitHub label names and whether the repository already has them.
+2. Confirm the source and credential path for Pixabay API use.
+3. Confirm the Hugo-safe convention for `notes.md` inside leaf bundles.
+4. Decide whether image candidates should be stored as issue-comment URLs only or in a non-published review directory.
+5. Select the first pilot backlog issue and the automation cadence.


### PR DESCRIPTION
Closes #107

## Summary

- Adds the Editorial Agent skill, backlog issue template, state labels, image sourcing adapter, audit notes, social-draft workflow, and validation suite.
- Extends content provisioning to reuse an existing editorial issue rather than creating a duplicate.
- Keeps all generated posts as `draft: true` and requires a separate human publication approval.
- Includes the evaluator path fix found during the live #108 scheduled-task test.

## Validation

- Skill-creator validation passed.
- Pixabay candidate search returned three real-photo candidates from the configured project `.env`.
- Editorial package and Managing Editor validation passed in the live #108 run.
- Hugo build passed.