### PR TITLE
fix: require contextual editorial links

### DIFF
--- a/.agents/skills/editorial-agent/SKILL.md
+++ b/.agents/skills/editorial-agent/SKILL.md
@@ -22,7 +22,7 @@ Never change `draft` to `false`, merge a PR, publish, or post social content unl
 3. Propose the content type from the brief. Use Articles for strategic analysis, Labs for technical work, Videos for a primary video URL, and Research for evidence-led analysis. Record the choice in the issue.
 4. Invoke `content-research-writer` when the issue needs research or a full draft. Preserve a supplied draft unless substantial rewriting is authorized.
 5. Invoke `content-creator` with the existing issue identifier. Do not create a second issue. Create a new issue only when this skill is invoked directly without one.
-6. Invoke `managing-editor` to enforce taxonomy, metadata, AEO structure, internal links, and draft status. Force `draft: true` regardless of supplied frontmatter.
+6. Invoke `managing-editor` to enforce taxonomy, metadata, AEO structure, internal links, and draft status. Run `internal-linker` with `--allow-draft-target`, read its shortlist, and add 2 to 4 relevant contextual Hugo links to the draft itself. Record the selected paths and rationale in `notes.md` and the issue. A `No contextual-link fit:` exception requires a concise rationale. Force `draft: true` regardless of supplied frontmatter.
 7. Source three featured-image candidates. Prefer licensed real photography. When `PIXABAY_API_KEY` is available, use `scripts/find_pixabay_candidates.py` and read `references/pixabay.md`. Record candidate URLs, rights basis, and selection rationale. Commit only the selected 16:9 landscape asset. Use image generation only when real photography cannot express the argument and the brief does not prohibit it.
 8. Create `notes.md` from the bundled template. Include the concise decision record, not private reasoning.
 9. Invoke `repurpose-social` to save X and LinkedIn candidates under `docs/repurposed/`. Draft only. Do not post.
@@ -31,7 +31,7 @@ Never change `draft` to `false`, merge a PR, publish, or post social content unl
 
 ## Authority
 
-Act without approval only for the issue states, drafting, existing taxonomy, feature-image selection with clear rights, branch creation, validation, and PR creation defined above.
+Act without approval only for the issue states, drafting, contextual edits to the draft the agent owns, existing taxonomy, feature-image selection with clear rights, branch creation, validation, and PR creation defined above.
 
 Require human approval for a new category or tag, private or paid sources without explicit issue permission, changing unrelated published posts, publishing, merging, and social posting.
 

--- a/.agents/skills/editorial-agent/assets/notes.md
+++ b/.agents/skills/editorial-agent/assets/notes.md
@@ -6,6 +6,8 @@
 
 ## Research basis and citations
 
+## Internal linking record
+
 ## Featured image candidates and selected asset
 
 ## Social draft archive

--- a/.agents/skills/editorial-agent/references/workflow.md
+++ b/.agents/skills/editorial-agent/references/workflow.md
@@ -37,6 +37,7 @@ Use concise, decision-useful updates. Do not expose private reasoning.
 - Rationale: `<one concise paragraph>`
 - Research basis: `<primary sources and permitted secondary sources>`
 - Taxonomy: `<category and tags, or approval request>`
+- Internal links: `<selected target-draft paths and rationale; incoming recommendations if any>`
 - Featured image: `<three candidate URLs, rights basis, and selection>`
 - Social drafts: `<path>`
 ```

--- a/.agents/skills/editorial-agent/scripts/validate_editorial_package.py
+++ b/.agents/skills/editorial-agent/scripts/validate_editorial_package.py
@@ -13,6 +13,7 @@ REQUIRED_NOTE_HEADINGS = {
     "Brief and intended reader",
     "Content-type and taxonomy rationale",
     "Research basis and citations",
+    "Internal linking record",
     "Featured image candidates and selected asset",
     "Social draft archive",
     "Validation record",
@@ -28,6 +29,10 @@ def frontmatter(path: Path):
     return yaml.safe_load(match.group(1)) or {}
 
 
+def contextual_link_paths(content: str) -> set[str]:
+    return set(re.findall(r'\]\(\{\{<\s*(?:ref|relref)\s+"([^"]+)"\s*>\}\}\)', content))
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("bundle", type=Path, help="Content leaf bundle directory")
@@ -38,14 +43,19 @@ def main():
     bundle = args.bundle
     index = bundle / "index.md"
     notes = bundle / "notes.md"
+    needs_contextual_links = False
 
     if not index.is_file():
         errors.append(f"Missing index.md: {index}")
     else:
         try:
+            index_content = index.read_text(encoding="utf-8")
             metadata = frontmatter(index)
             if metadata.get("draft") is not True:
                 errors.append("Frontmatter must set draft: true")
+            links = contextual_link_paths(index_content)
+            if len(links) < 2:
+                needs_contextual_links = True
         except (OSError, ValueError, yaml.YAMLError) as exc:
             errors.append(f"Invalid frontmatter: {exc}")
 
@@ -60,6 +70,10 @@ def main():
         missing = sorted(REQUIRED_NOTE_HEADINGS - headings)
         if missing:
             errors.append(f"notes.md missing headings: {', '.join(missing)}")
+        elif needs_contextual_links:
+            notes_content = notes.read_text(encoding="utf-8")
+            if "No contextual-link fit:" not in notes_content:
+                errors.append("Missing contextual links or a documented No contextual-link fit exception")
 
     if not any(bundle.glob("featured.*")):
         errors.append("Missing selected featured image named featured.<extension>")

--- a/.agents/skills/internal-linker/SKILL.md
+++ b/.agents/skills/internal-linker/SKILL.md
@@ -17,7 +17,7 @@ Use this skill to make a considered recommendation or an approved edit. Do not a
      content/articles/example/index.md --limit 4
    ```
 
-   Pass `--content-dir content/articles` when the target lives outside the default corpus. The helper ranks published articles with tag, category, keyword, and recency signals. Treat its results as a shortlist, not a decision.
+   Pass `--content-dir content/articles` when the target lives outside the default corpus. For a new draft, add `--allow-draft-target`; it permits only the target to be a draft and keeps the candidate corpus published. The helper ranks articles with tag, category, keyword, and recency signals. Treat its results as a shortlist, not a decision.
 3. Read every shortlisted source file before recommending it. Reject a candidate if the connection is generic, duplicated by an existing internal link, or cannot be justified in the target's own language.
 4. Select 2 to 4 outgoing and 2 to 4 incoming recommendations. Favor complementary depth, a prerequisite, a useful extension, or direct supporting evidence. Prefer material published in the past 12 to 18 months when relevance is otherwise comparable.
 5. Write exact, minimal suggestions. For outgoing links, quote the nearby text and add a natural transition after the relevant paragraph, bullet, or FAQ answer. For incoming links, identify the precise paragraph in the source article and supply its proposed sentence.

--- a/.agents/skills/internal-linker/scripts/find_link_candidates.py
+++ b/.agents/skills/internal-linker/scripts/find_link_candidates.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Rank related published Hugo articles for an internal-linking review."""
+"""Rank published Hugo articles for an internal-linking review."""
 
 from __future__ import annotations
 
@@ -50,9 +50,13 @@ def hugo_path(markdown_path: Path, content_dir: Path) -> str:
     return relative.removesuffix("/index.md").removesuffix(".md")
 
 
-def parse_article(path: Path, content_dir: Path) -> dict[str, Any] | None:
+def parse_article(
+    path: Path, content_dir: Path, *, allow_draft: bool = False
+) -> dict[str, Any] | None:
     frontmatter, body = frontmatter_and_body(path.read_text(encoding="utf-8"))
-    if not frontmatter or scalar(frontmatter, "draft").lower() == "true":
+    if not frontmatter:
+        return None
+    if scalar(frontmatter, "draft").lower() == "true" and not allow_draft:
         return None
     if re.search(r"^externalUrl:\s*[\"']?https?://", frontmatter, re.MULTILINE):
         return None
@@ -108,15 +112,20 @@ def main() -> None:
     parser.add_argument("--content-dir", default="content/articles", help="Published article corpus")
     parser.add_argument("--limit", type=int, default=4, choices=range(1, 11), metavar="1-10")
     parser.add_argument("--as-of", help="Use YYYY-MM-DD as the ranking date for reproducible results")
+    parser.add_argument(
+        "--allow-draft-target",
+        action="store_true",
+        help="Allow the target to be a draft while retaining a published-only candidate corpus",
+    )
     args = parser.parse_args()
     content_dir = Path(args.content_dir).resolve()
     target_path = Path(args.target).resolve()
     if not content_dir.is_dir() or not target_path.is_file():
         parser.error("target and content directory must exist")
     articles = [article for file in content_dir.rglob("*.md") if (article := parse_article(file, content_dir))]
-    target = next((article for article in articles if Path(article["file"]) == target_path), None)
+    target = parse_article(target_path, content_dir, allow_draft=args.allow_draft_target)
     if not target:
-        parser.error("target must be a published Markdown article inside --content-dir")
+        parser.error("target must be a published article, or use --allow-draft-target for a draft")
     try:
         as_of = date.fromisoformat(args.as_of) if args.as_of else date.today()
     except ValueError:

--- a/.agents/skills/managing-editor/SKILL.md
+++ b/.agents/skills/managing-editor/SKILL.md
@@ -72,7 +72,7 @@ showReadingTime: false
     *   **Semantic Hierarchy:** H2 headings (`##`) phrased as questions where possible.
     *   **FAQ Section:** Conclude with `{{< faq >}}` block and at least 2-3 `{{% faq-item %}}` pairs.
     *   **Related/Read-Next:** MUST conclude with `{{< related-posts ... >}}` and `{{< read-next ... >}}`. Use `related-posts-suggester` and `read-next-suggester`.
-    *   **Internal Linking:** After the draft is complete, use `internal-linker` for Articles, Videos, and Labs to identify contextual outgoing links, incoming-link opportunities, and an optional Further Reading section. Apply target-page edits only when authorized. Present edits to other published pages separately for approval. Do not force a Further Reading section or duplicate destinations already covered by `related-posts` or `read-next`.
+    *   **Internal Linking:** After the draft is complete, use `internal-linker` for Articles, Videos, and Labs to identify 2 to 4 contextual outgoing links, incoming-link opportunities, and an optional Further Reading section. For a draft target, run the helper with `--allow-draft-target`. When an outer Editorial Agent owns the draft, apply relevant target-page links without further approval and record them in `notes.md`. Present edits to other published pages separately for approval. Do not force a Further Reading section or duplicate destinations already covered by `related-posts` or `read-next`.
 *   **Images:** Use `{{< figure src="image.png" alt="SEO text" caption="Visible caption" >}}`.
 *   **Draft protection:** Set `draft: true` for every newly created or edited agent-managed post. Publishing is a separate, explicit workflow.
 

--- a/.agents/skills/managing-editor/evals/checks/links.py
+++ b/.agents/skills/managing-editor/evals/checks/links.py
@@ -3,6 +3,9 @@ import os
 import re
 import json
 
+
+CONTEXTUAL_LINK = re.compile(r'\]\(\{\{<\s*(?:ref|relref)\s+"([^"]+)"\s*>\}\}\)')
+
 def check_links(article_path):
     errors = []
     
@@ -12,6 +15,8 @@ def check_links(article_path):
 
     with open(article_path, 'r', encoding='utf-8') as f:
         content = f.read()
+
+    contextual_paths = set(CONTEXTUAL_LINK.findall(content))
 
     # Check Related Posts
     if "{{< related-posts" not in content:
@@ -29,11 +34,20 @@ def check_links(article_path):
         if 'link="' not in content:
             errors.append("'{{< read-next >}}' shortcode is missing the 'link' parameter")
 
+    if len(contextual_paths) < 2:
+        notes_path = os.path.join(os.path.dirname(article_path), "notes.md")
+        no_fit_exception = False
+        if os.path.isfile(notes_path):
+            with open(notes_path, 'r', encoding='utf-8') as f:
+                no_fit_exception = "No contextual-link fit:" in f.read()
+        if not no_fit_exception:
+            errors.append("Missing at least two contextual Hugo ref or relref links")
+
     if errors:
         print(json.dumps({"errors": errors}))
         return 1
     else:
-        print(json.dumps({"message": "Semantic navigation (Related Posts & Read Next) verified with parameters"}))
+        print(json.dumps({"message": f"Semantic navigation verified with {len(contextual_paths)} contextual links"}))
         return 0
 
 if __name__ == "__main__":

--- a/content/articles/is-ai-killing-book-reading/index.md
+++ b/content/articles/is-ai-killing-book-reading/index.md
@@ -50,9 +50,13 @@ AI changes the cost of producing an answer. It does not remove the cost of under
 
 That distinction matters in executive work. You can ask a model to summarize a market, compare competitors, or draft an investment memo. You cannot safely outsource the judgment about what is missing, which incentives matter, or what would break the conclusion.
 
+That is the difference between [discovery and knowledge]({{< ref "articles/discovery-to-knowledge" >}}). AI can reveal a field faster than any person can, but it cannot decide which finding matters to your business or carry the accountability for acting on it.
+
 The early research supports caution, not panic. A 2025 CHI study of 319 knowledge workers found that people often reported less effort on cognitive tasks when using generative AI. The authors were explicit that their study did not establish causation. Their more useful observation was that the work shifts: from gathering information to verifying outputs, integrating responses, and supervising the tool. [Read the paper](https://doi.org/10.1145/3706598.3713778).
 
 That is the management problem. If AI removes the lower-value effort but we keep the verification and synthesis, it can make teams stronger. If it removes the struggle before anyone develops a point of view, it can make teams faster and shallower at the same time.
+
+Forming that point of view requires choosing the right level of abstraction, not processing every available detail. That is the practical value of [strategic forgetting and world models]({{< ref "articles/world-models" >}}) for leaders using AI.
 
 ## Why is attention still a leadership issue?
 
@@ -69,6 +73,8 @@ I would set three operating rules.
 1. **Read before you prompt on the work that matters.** For a board decision, investment thesis, regulatory change, or strategic partnership, start with the primary document. Use AI after you have a provisional view.
 2. **Make verification visible.** Require a source list, a counterargument, and a statement of uncertainty in AI-assisted work. “The model said so” is not analysis.
 3. **Protect uninterrupted depth.** Give people time to read and write without the feed, chat, or model in the loop. This is not nostalgia. It is how you preserve the ability to form an original position.
+
+That discipline needs an operating design, not a calendar slogan. [Architecture of Attention]({{< ref "articles/architecture-of-attention" >}}) makes the case for treating information synthesis and focused analysis as deliberate capabilities.
 
 The goal is not to make teams slower. It is to make sure speed does not hide a collapse in comprehension.
 
@@ -99,6 +105,6 @@ Books are not dying. But the discipline that books represent can atrophy if we l
   {{% /faq-item %}}
 {{< /faq >}}
 
-{{< related-posts title="Related Insights" paths="articles/discovery-to-knowledge, articles/moats-vibe-coding" >}}
+{{< related-posts title="Related Insights" paths="articles/the-next-compiler, articles/burke-lecture" >}}
 
 {{< read-next title="Read Next" link="articles/mit-ai-report-2025" buttonText="View More Insights" buttonLink="/articles/" >}}

--- a/content/articles/is-ai-killing-book-reading/notes.md
+++ b/content/articles/is-ai-killing-book-reading/notes.md
@@ -15,6 +15,13 @@ Article, Technology. The post examines AI as an enabling technology and its effe
 - CHI 2025 study of 319 knowledge workers: reported cognitive-effort shifts with GenAI, not causal proof.
 - Bonifacci et al. meta-analysis: relationship between mind wandering and reading comprehension.
 
+## Internal linking record
+
+- `articles/discovery-to-knowledge`: AI can accelerate discovery but cannot replace accountable judgment.
+- `articles/world-models`: forming a view requires selecting the right level of abstraction.
+- `articles/architecture-of-attention`: focused reading and synthesis need an operating design.
+- Incoming-link suggestions were not applied because they would modify older published posts and still require human approval.
+
 ## Featured image candidates and selected asset
 
 All candidates were returned by Pixabay as horizontal photos and were checked for text, logos, watermarks, and the `AI generated` tag.

--- a/docs/editorial-agent-prd.md
+++ b/docs/editorial-agent-prd.md
@@ -24,9 +24,9 @@ The Managing Editor remains a reusable specialist skill. The Editorial Agent dec
 A content job is complete when all of the following are true:
 
 1. A leaf bundle exists in the correct section and approved path.
-2. The content type, frontmatter, taxonomy, citations, internal links, and AEO elements meet the published rules.
+2. The content type, frontmatter, taxonomy, citations, AEO elements, and 2 to 4 relevant contextual outbound internal links meet the published rules. A no-fit exception requires a concise record in `notes.md` and the issue.
 3. The selected featured image is relevant, licensed for use, 16:9 landscape, substantially free of text, and stored in the bundle with required attribution recorded.
-4. `notes.md` records the editorial brief, source basis, taxonomy rationale, image candidates and selection, validation outcomes, and unresolved questions.
+4. `notes.md` records the editorial brief, source basis, taxonomy rationale, internal-link decision record, image candidates and selection, validation outcomes, and unresolved questions.
 5. Required deterministic checks, including the Hugo build, pass.
 6. The post frontmatter explicitly sets `draft: true`.
 7. The work is committed and a GitHub PR linked to the original backlog issue is open.
@@ -206,6 +206,7 @@ Required entries:
 ## Brief and intended reader
 ## Content-type and taxonomy rationale
 ## Research basis and citations
+## Internal linking record
 ## Featured image candidates and selected asset
 ## Social draft archive
 ## Validation record
@@ -251,6 +252,7 @@ The Editorial Agent inherits the Managing Editor evaluation suite and adds agent
 - Image is present when required, is landscape 16:9 or compatible with approved crop policy, and has no substantial embedded text.
 - Image source, attribution, and license basis are recorded.
 - Every agent-created post has `draft: true`, regardless of supplied frontmatter.
+- Every agent-created post has 2 to 4 contextual Hugo `ref` or `relref` links to distinct published pages, or a documented no-fit exception. The draft target may be analyzed, but candidate links must remain published content.
 - The agent cannot mark a job review-ready or create its PR if `draft: false`.
 - A social-draft archive exists for the post and contains X and LinkedIn candidates created by the existing `repurpose-social` skill.
 - No duplicate issue is created when the agent begins from an existing backlog issue.


### PR DESCRIPTION
Closes #111

## Summary

- Allows internal-linker to analyze a `draft: true` target while limiting recommendations to published content.
- Requires 2 to 4 contextual Hugo links in Editorial Agent drafts, with a documented no-fit exception.
- Gives the Editorial Agent authority to apply links only to the draft it owns, while preserving approval for edits to older published pages.
- Updates article #108 with three contextual links and records the rationale in `notes.md`.

## Validation

- Draft target is rejected without `--allow-draft-target` and accepted with it.
- Managing Editor evaluator: pass.
- Editorial package evaluator: pass.
- Hugo build: pass.